### PR TITLE
bluetoool: blueserver: reset alias on hostname change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='bluetool',
-    version='0.4.0',
+    version='0.4.1',
     license='GPL',
     author='Aleksandr Aleksandrov',
     author_email='aleksandr.aleksandrov@emlid.com',


### PR DESCRIPTION
As changing the bluetooth adapter name  without restarting it is impossible (as far as my research got), we probably should add a signal receiver, which handles the hostname changes and resets the "Alias Name", which is a [bluetooth-friendly changeable field](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt#n224), which acts as a "Name" one.

We should also reset Alias Name on server initialization, as it could be changed while the service was down and we wouldn't know.